### PR TITLE
Fix npm run serve script

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -7,7 +7,7 @@
     "test": "NODE_ENV=test jest",
     "start": "if-env NODE_ENV=production && npm run -s serve || npm run -s dev",
     "build": "preact build --no-prerender --clean --template src/index.ejs --service-worker false",
-    "serve": "preact build && preact serve",
+    "serve": "npm run build && preact serve",
     "dev": "preact watch --template src/index.ejs"
   },
   "keywords": [],


### PR DESCRIPTION
`npm run serve` is not working:

```bash
npm run serve

> preact-cli-widget@0.1.0 serve /Users/***/playground/preact-cli-widget
> preact build && preact serve

Build [==================  ] 91% (2.9s) additional chunk assets processing(node:54773) DeprecationWarning: Chunk.modules is deprecated. Use Chunk.getNumberOfModules/mapModules/forEachModule/containsModule instead.
Build [==================  ] 91% (0.4s) additional chunk assets processingUnable to read file: /Users/***/playground/preact-cli-widget/src/node_modules/style-loader/lib/addStyles.js

ReferenceError: window is not defined
method: null
at: /Users/***/playground/preact-cli-widget/src/node_modules/style-loader/lib/addStyles.js:23:1

Source code:


This is most likely caused by using DOM or Web APIs.
Pre-render runs in node and has no access to globals available in browsers.

Consider wrapping code producing error in: 'if (typeof window !== "undefined") { ... }'

Alternatively use 'preact build --no-prerender' to disable prerendering.

See https://github.com/developit/preact-cli#pre-rendering for further information.npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! preact-cli-widget@0.1.0 serve: `preact build && preact serve`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the preact-cli-widget@0.1.0 serve script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/***/.npm/_logs/2018-04-09T09_07_03_190Z-debug.log


node --version
v8.9.3
```

The problem is the `preact build` takes the index.js as the entry point, but the widget template's entry point is `index.ejs`. So the `preact build` failed while trying to access the wrong entry.

The fix just simply run the production build script which gives the right entry point and serve it after.