### PR TITLE
adding microbundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ $ npm run dev
 
 *dev:* Starts a dev server with hotreload and widget placeholder.
 
-*build:* Builds production ready UMD bundle ready to be embedded in any page.
+*build:* Builds a documentation web app in `build` folder and a production ready UMD bundle ready to be embedded in any non-preact page.
+
+*dist:* Builds bundles in `dist` folder to be consumed by other `preact` web apps.
 
 *start:* Either starts a production ready dev server demo-ing your widget or local env based on your environment variable.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm run dev
 
 *build:* Builds a documentation web app in `build` folder and a production ready UMD bundle ready to be embedded in any non-preact page.
 
-*dist:* Builds bundles in `dist` folder to be consumed by other `preact` web apps.
+*dist:* Builds npm ready bundles in `dist` folder to be consumed by other `preact` web apps.
 
 *start:* Either starts a production ready dev server demo-ing your widget or local env based on your environment variable.
 

--- a/template/package.json
+++ b/template/package.json
@@ -2,13 +2,17 @@
   "name": "widgets-template",
   "version": "0.1.0",
   "description": "",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "umd:main": "dist/index.umd.js",
+  "module": "dist/index.m.js",
+  "source": "components/hello-world/index.js",
   "scripts": {
     "test": "NODE_ENV=test jest",
     "start": "if-env NODE_ENV=production && npm run -s serve || npm run -s dev",
     "build": "preact build --no-prerender --clean --template src/index.ejs --service-worker false",
     "serve": "npm run build && preact serve",
-    "dev": "preact watch --template src/index.ejs"
+    "dev": "preact watch --template src/index.ejs",
+    "dist": "microbundle --entry src/components/hello-world/index.js"
   },
   "keywords": [],
   "author": "Zouhir <zouhir@zouhir.org>",
@@ -18,6 +22,7 @@
     "identity-obj-proxy": "^3.0.0",
     "if-env": "^1.0.0",
     "jest": "^21.2.1",
+    "microbundle": "^0.6.0",
     "node-sass": "^4.5.3",
     "preact-cli": "^2.0.2",
     "preact-render-to-string": "^3.7.0",


### PR DESCRIPTION
This PR adds `microbundle` to the repo and exports bundles created by it in the `dist` folder.
These bundles can be consumed by any preact project as any other component they would be already using.

In order to create these bundles, they would be required to run `num run dist`.

After this PR

npm run build -> outputs a webapp, which can be used as a documentation site or I assume that the `index.js` in build folder can also be used to be embedded anywhere.

npm run dist -> outputs a preact component to be used by preact ecosystem.